### PR TITLE
Fix hole punching in mappings with SVC `UnmapPhysicalMemory`

### DIFF
--- a/app/src/main/cpp/skyline/kernel/svc.cpp
+++ b/app/src/main/cpp/skyline/kernel/svc.cpp
@@ -1084,6 +1084,9 @@ namespace skyline::kernel::svc {
                         }
                     } else if (memory->guest.data() < pointer) {
                         memory->Resize(static_cast<size_t>(pointer - memory->guest.data()));
+
+                        if (memory->guest.data() + initialSize > end)
+                            state.process->NewHandle<type::KPrivateMemory>(span<u8>{end, static_cast<size_t>(memory->guest.data() + initialSize - end)}, memory::Permission{true, true, false}, memory::states::Heap);
                     }
                 }
                 pointer += initialSize;


### PR DESCRIPTION
Certain titles such as Super Smash Bros Ultimate can use SVC `UnmapPhysicalMemory` to punch holes into physical memory mappings, this wasn't handled correctly as we completely deleted the portion after the hole. It has now been fixed which results in these titles which depend on this behavior to work now.